### PR TITLE
Agregada rutas relativas a la carpeta CSS

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import GruposView from './Views/GruposView';
 import DetalleGruposView from './Views/DetalleGruposView';
 
 //Css 
-import '../src/CSS/App.css';
+import '@css/App.css';
 
 
 

--- a/src/CSS/Layout/AdminLayout.css
+++ b/src/CSS/Layout/AdminLayout.css
@@ -2,7 +2,6 @@
     min-height: 100dvh;
 }
 
-
 .AdminLayoutContent{
     padding-inline: 1rem;
     background-color: rgb(var(--conifer-50));

--- a/src/Components/Auth/Login.jsx
+++ b/src/Components/Auth/Login.jsx
@@ -1,4 +1,4 @@
-import '../../CSS/Auth/Login.css';
+import '@css/Auth/Login.css';
 
 
 export default function Login() {

--- a/src/Components/General/CardContent.jsx
+++ b/src/Components/General/CardContent.jsx
@@ -2,14 +2,13 @@
 import { Card } from 'antd';
 
 //CSS
-import '../../CSS/General/CardContent.css';
+import '@css/General/CardContent.css';
 
 
-export default function CardContent({ children, className }){
+export default function CardContent({ children, ...rest } = {}){
 
     return(
-
-        <Card className={ className } hoverable>
+        <Card {...rest}>
             { children }
         </Card>
     );

--- a/src/Components/Layout/HeaderLayout.jsx
+++ b/src/Components/Layout/HeaderLayout.jsx
@@ -13,7 +13,8 @@ import { IconMainLogo } from "../../Js/Icons";
 import { IconUserFill } from "../../Js/Icons";
 import { IconBackArrow } from "../../Js/Icons";
 
-import '../../CSS/Layout/HeaderComponent.css';
+// import '../../CSS/Layout/HeaderComponent.css';
+import '@css/Layout/HeaderComponent.css';
 
 export default function HeaderLayout(){
 

--- a/src/Components/Layout/NavbarComponent.jsx
+++ b/src/Components/Layout/NavbarComponent.jsx
@@ -12,7 +12,7 @@ import { IconBaselineDensityMedium } from '@tabler/icons-react';
 import { IconIndentIncrease } from '@tabler/icons-react';
 
 //Css
-import '../../CSS/Layout/NavbarComponent.css';
+import '@css/Layout/NavbarComponent.css';
 
 
 

--- a/src/Components/Layout/SiderNav.jsx
+++ b/src/Components/Layout/SiderNav.jsx
@@ -10,7 +10,7 @@ const { Sider } = Layout;
 import NavbarComponent from "./NavbarComponent";
 
 //CSS
-import '../../CSS/Layout/Sider.css';
+import '@css/Layout/Sider.css';
 
 
 export default function SiderNav(){

--- a/src/Layout/AdminLayout.jsx
+++ b/src/Layout/AdminLayout.jsx
@@ -10,7 +10,7 @@ import { Layout } from 'antd';
 const { Content, Footer } = Layout;
 
 //Css
-import '../CSS/Layout/AdminLayout.css';
+import '@css/Layout/AdminLayout.css';
 
 export default function AdminLayout({children}){
 

--- a/src/Views/DetalleGruposView.jsx
+++ b/src/Views/DetalleGruposView.jsx
@@ -12,7 +12,8 @@ import FakeAPI from "../Js/FakeApi";
 import CardContent from "../Components/General/CardContent";
 
 //Css
-import '../CSS/Views/GruposView.css';
+
+import '@css/Views/GruposView.css';
 
 
 export default function DetalleGruposView(){

--- a/src/Views/DivisionView.jsx
+++ b/src/Views/DivisionView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import FakeAPI from "../Js/FakeApi";
 
@@ -12,7 +12,7 @@ import { AdministracionIcon } from "../Js/Icons";
 import { Col, Row, Divider } from "antd";
 
 //Css
-import '../CSS/Views/DivisionView.css';
+import '@css/Views/DivisionView.css';
 
 export default function DivisionView(){
 

--- a/src/Views/GruposView.jsx
+++ b/src/Views/GruposView.jsx
@@ -12,8 +12,7 @@ import FakeAPI from "../Js/FakeApi";
 import CardContent from "../Components/General/CardContent";
 
 //Css
-import '../CSS/Views/GruposView.css';
-
+import '@css/Views/GruposView.css';
 
 export default function GruposView(){
 

--- a/src/Views/HomeView.jsx
+++ b/src/Views/HomeView.jsx
@@ -7,7 +7,7 @@ import { IconCertificate } from '../Js/Icons';
 import { IconMail } from "../Js/Icons";
 
 //Css
-import '../CSS/Views/HomeView.css';
+import '@css/Views/HomeView.css';
 
 import { useNavigate } from "react-router-dom";
 
@@ -21,7 +21,7 @@ export default function HomeView(){
             <h1 className="HomeTittle">Bienvenido {Usuario} </h1>
             <Row className="MainOpcion" gutter={[16, 16]}>
                 <Col xs={24} sm={12} lg={8}>
-                    <CardContent className={'CardMenu'}>
+                    <CardContent className={'CardMenu'} hoverable>
                         <Row className="HeaderCard" onClick={() => { navigate('/Divisiones')}}>
                             <IconSchool strokeColor={"rgb(var(--conifer-700))"} strokeWidth={2} size={200}></IconSchool>
                         </Row>
@@ -34,7 +34,7 @@ export default function HomeView(){
                 </Col>
 
                 <Col xs={24} sm={12} lg={8}>
-                    <CardContent className={'CardMenu'}>
+                    <CardContent className={'CardMenu'} hoverable>
                         <Row className="HeaderCard">
                             <IconMail strokeColor={"rgb(var(--conifer-700))"} strokeWidth={2} size={200}></IconMail>
                         </Row>
@@ -47,7 +47,7 @@ export default function HomeView(){
                 </Col>
 
                 <Col xs={24} sm={12} lg={8}>
-                    <CardContent className={'CardMenu'}>
+                    <CardContent className={'CardMenu'} hoverable>
                         
                             <Row className="HeaderCard">
                                 <IconCertificate strokeColor={"rgb(var(--conifer-700))"} strokeWidth={2} size={200}></IconCertificate>

--- a/src/index.css
+++ b/src/index.css
@@ -43,3 +43,4 @@ body{
   background-color: rgb(245, 245, 255);
   font-family: 'Inter' !important;
 }
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -7,6 +8,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs',
+      '@css': path.resolve(__dirname, 'src/CSS'),
     },
   },
+
 })


### PR DESCRIPTION
Mejoras en la importación de archivos CSS, se cambian las rutas absolutas por rutas relativas con la palabra clave @css, importación de css más cómoda y limpia, en consonancia con la estructura de carpetas actual. 
![Importacion mejorada css](https://github.com/user-attachments/assets/3b270e87-e8f2-4d9b-a064-1d58b6613999)
